### PR TITLE
task/TCP

### DIFF
--- a/internal/test/http/http_service.go
+++ b/internal/test/http/http_service.go
@@ -17,5 +17,5 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	http.HandleFunc("/health", healthHandler)
-	http.ListenAndServe(":8080", nil)
+	http.ListenAndServe(":8001", nil)
 }

--- a/internal/test/tcp/tcp_service.go
+++ b/internal/test/tcp/tcp_service.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+)
+
+func handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	conn.Write([]byte("Server received your connection!\n"))
+	fmt.Println("Handled connection")
+}
+
+func startServer(port string) {
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Fatal(err)
+		}
+		go handleConnection(conn)
+	}
+}
+
+func main() {
+	port := "8002"
+	fmt.Printf("Starting server on port %s\n", port)
+	startServer(port)
+}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2,6 +2,7 @@ package healthcheck
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -28,7 +29,7 @@ type HealthCheckResult struct {
 }
 
 func NewHealthChecker(config HealthCheck) (HealthChecker, error) {
-	switch config.Interface {
+	switch strings.ToLower(config.Interface) {
 	case "http", "https":
 		return &HTTPChecker{
 			Endpoint: config.Endpoint,
@@ -36,6 +37,11 @@ func NewHealthChecker(config HealthCheck) (HealthChecker, error) {
 			Port:     config.Port,
 			Protocol: config.Interface,
 			Match:    config.Match,
+		}, nil
+	case "tcp":
+		return &TCPChecker{
+			Host: config.Host,
+			Port: config.Port,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported interface: %s", config.Interface)

--- a/pkg/healthcheck/http.go
+++ b/pkg/healthcheck/http.go
@@ -17,8 +17,6 @@ type HTTPChecker struct {
 }
 
 func (h *HTTPChecker) CheckHealth() HealthCheckResult {
-	// url := fmt.Sprintf("%s://%s:%d/%s", h.Protocol, h.Host, h.Port, h.Endpoint)
-
 	url := strings.Builder{}
 
 	url.WriteString(h.Protocol)

--- a/pkg/healthcheck/tcp.go
+++ b/pkg/healthcheck/tcp.go
@@ -1,0 +1,26 @@
+package healthcheck
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+type TCPChecker struct {
+	Host string
+	Port int
+}
+
+func (t *TCPChecker) CheckHealth() HealthCheckResult {
+	start := time.Now()
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", t.Host, t.Port))
+	response_time := time.Since(start)
+	isHealthy := false
+
+	if err == nil {
+		conn.Close()
+		isHealthy = true
+	}
+
+	return HealthCheckResult{IsHealthy: isHealthy, ResponseTime: response_time, Error: err}
+}


### PR DESCRIPTION
- Basic HTTTP/HTTPS Check
- fuck comments
- Update example config file
- Add /health and /status endpoints
- Allow healthcheck to not use port nor endpoint
- No more logs and builder variable
- Add README.md
- fmt
- Add metrics #9
- Replace list of metrics with MetricVec
- TCP handler
